### PR TITLE
feat(cli): continue searching until arriving at your home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,9 +423,9 @@ If no configuration is found, then the [default](lib/defaults/index.js) configur
 ```js
 const JoiConfigSchema = Joi.object({
   order: Joi.array()
-    .min(0)
+    .min(1)
     .unique()
-    .required(),
+    .optional(),
   transformations: Joi.object().optional(),
   formatter: Joi.func().optional(),
 });

--- a/README.md
+++ b/README.md
@@ -424,7 +424,8 @@ If no configuration is found, then the [default](lib/defaults/index.js) configur
 const JoiConfigSchema = Joi.object({
   order: Joi.array()
     .min(0)
-    .unique(),
+    .unique()
+    .required(),
   transformations: Joi.object().optional(),
   formatter: Joi.func().optional(),
 });

--- a/lib/cli/__fixtures__/invalid-config-order.js
+++ b/lib/cli/__fixtures__/invalid-config-order.js
@@ -1,0 +1,3 @@
+module.exports = {
+  order: ['name', 'name'],
+};

--- a/lib/cli/__fixtures__/invalid-config.js
+++ b/lib/cli/__fixtures__/invalid-config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/lib/cli/__fixtures__/valid-config-order.js
+++ b/lib/cli/__fixtures__/valid-config-order.js
@@ -1,0 +1,3 @@
+module.exports = {
+  order: ['name'],
+};

--- a/lib/cli/config-schema.js
+++ b/lib/cli/config-schema.js
@@ -3,8 +3,9 @@ const Joi = require('@hapi/joi');
 // region Joi Schema
 const JoiConfigSchema = Joi.object({
   order: Joi.array()
-    .min(0)
-    .unique(),
+    .min(1)
+    .unique()
+    .optional(),
   transformations: Joi.object().optional(),
   formatter: Joi.func().optional(),
 });

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -3,6 +3,7 @@ const { existsSync, readFileSync } = require('fs');
 
 const cosmiconfig = require('cosmiconfig');
 const Joi = require('@hapi/joi');
+const { ValidationError } = require('@hapi/joi/lib/errors');
 const resolveFrom = require('resolve-from');
 
 const JSON5 = require('json5');
@@ -12,15 +13,27 @@ const { JoiConfigSchema } = require('./config-schema');
 const configDefault = {
   config: require('../defaults'),
   filepath: require.resolve('../defaults'),
+  isDefault: true,
 };
 
 const configValidate = config => {
-  return Joi.validate(config, JoiConfigSchema);
+  const result = Joi.validate(config, JoiConfigSchema);
+  if (result.error) return result;
+  if (!Array.isArray(config.order)) {
+    return {
+      error: new ValidationError('empty order property')
+    };
+  }
+  return result;
 };
 
 const configModuleName = 'format-package';
 
 const resolveModuleOrPath = ({ configPath, searchFrom }) => {
+  if (typeof configPath !== 'string') {
+    return undefined;
+  }
+
   // resolve as a node_modules, if undefined default to path.resolve if exists
   let resolvedPath = resolveFrom.silent(
     searchFrom || process.cwd(),
@@ -56,9 +69,8 @@ const loadConfig = configPath => {
   return explorer.load(configPath);
 };
 
-const searchPlaces = ({ configPath, searchFrom, moduleName }) =>
+const searchPlaces = ({ moduleName }) =>
   [
-    configPath && resolveModuleOrPath({ configPath, searchFrom }),
     moduleName && `${moduleName}.js`,
     moduleName && `${moduleName}.yaml`,
     moduleName && `${moduleName}.yml`,
@@ -70,12 +82,35 @@ const searchPlaces = ({ configPath, searchFrom, moduleName }) =>
   ].filter(Boolean);
 
 const search = async ({ configPath, searchFrom } = {}) => {
+  if (configPath) {
+    const resolvedPath = resolveModuleOrPath({ configPath, searchFrom });
+    return loadConfig(resolvedPath)
+      .then(result => {
+        const { error } = configValidate(result.config, JoiConfigSchema);
+
+        if (error) {
+          throw error;
+        }
+
+        return {
+          ...result,
+          error,
+        };
+      })
+      .catch(error => {
+        return {
+          ...configDefault,
+          error,
+        };
+      });
+  }
+
   const explorer = cosmiconfig(configModuleName, {
     packageProp: configModuleName,
-    searchPlaces: searchPlaces({ configPath, moduleName: configModuleName }),
-    stopDir: process.cwd(),
+    searchPlaces: searchPlaces({ moduleName: configModuleName }),
     loaders: createCosmiconfigLoader(),
   });
+
   return explorer
     .search(searchFrom)
     .then(result => {

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -21,7 +21,7 @@ const configValidate = config => {
   if (result.error) return result;
   if (!Array.isArray(config.order)) {
     return {
-      error: new ValidationError('empty order property')
+      error: new ValidationError('empty order property'),
     };
   }
   return result;

--- a/lib/cli/config.spec.js
+++ b/lib/cli/config.spec.js
@@ -47,7 +47,7 @@ describe('config', () => {
         configPath: 'format-package-config',
         searchFrom: `${process.cwd()}/examples/format-package-module`,
       });
-      expect(places.length).toEqual(2);
+      expect(places.length).toEqual(1);
     });
 
     it('should return a list with provided moduleName', () => {
@@ -119,6 +119,69 @@ describe('config', () => {
       expect(result.filepath).toEqual(configDefault.filepath);
       expect(result.error).toBeDefined();
       expect(result.error.message).toEqual('expected filepath to be a string');
+    });
+
+    it('should return config specified with configPath', async () => {
+      expect.assertions(4);
+
+      const configPath = `${process.cwd()}/examples/format-package-json/format-package.json`;
+      const result = await search({
+        configPath,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.filepath).toEqual(configPath);
+      expect(result.config).toBeDefined();
+      expect(result.config).toHaveProperty('order');
+    });
+
+    it('should return default when configPath fails schema validation with no order property', async () => {
+      expect.assertions(2);
+
+      const configPath = `${__dirname}/__fixtures__/invalid-config.js`;
+      const result = await search({
+        configPath,
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.filepath).toEqual(configDefault.filepath);
+    });
+
+    it('should return default when configPath fails schema validation with an empty order property', async () => {
+      expect.assertions(3);
+
+      const configPath = `${__dirname}/__fixtures__/invalid-config-order.js`;
+      const result = await search({
+        configPath,
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.error.name).toEqual('ValidationError');
+      expect(result.filepath).toEqual(configDefault.filepath);
+    });
+
+    it('should return default when configPath is not valid', async () => {
+      expect.assertions(3);
+
+      const result = await search({
+        configPath: {},
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.error.name).toEqual('Error');
+      expect(result.filepath).toEqual(configDefault.filepath);
+    });
+
+    it('should return when configPath passes schema validation', async () => {
+      expect.assertions(2);
+
+      const configPath = `${__dirname}/__fixtures__/valid-config-order.js`;
+      const result = await search({
+        configPath,
+      });
+
+      expect(result.error).toBeNull();
+      expect(result.filepath).toEqual(configPath);
     });
 
     it('should return config with JSON format', async () => {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -41,7 +41,9 @@ async function execute(argv) {
 
     const { globs, config: configPath, ignore, ...options } = parser(argv);
 
-    const { config } = await configSearch.search({ configPath });
+    const { config, filepath, isDefault } = await configSearch.search({
+      configPath,
+    });
 
     const files = await globby(globs, {
       onlyFiles: true,
@@ -55,7 +57,9 @@ async function execute(argv) {
 
     /* istanbul ignore next */
     console.log(
-      `✏️   Formatted ${files.length} file${files.length === 1 ? '' : 's'}`
+      `✏️   Formatted ${files.length} file${files.length === 1 ? '' : 's'} ${
+        isDefault ? '' : `with ${filepath}`
+      }`
     );
   } catch (err) {
     error(err);


### PR DESCRIPTION
- a. If the option `--config` or a `FORMAT_PACKAGE_CONFIG` is provided, skip searching and attempt to load the configuration.
- b. If the option `--config` or a `FORMAT_PACKAGE_CONFIG` is not provided, search for configurations until arriving at your home directory.

If there it is not a valid configuration from `a` or `b`, return the default configuration.