### PR TITLE
fix(docs): README formatting inconsistencies (#54)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "singleQuote": true,
-  "trailingComma": "es5"
-}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+};

--- a/README.md
+++ b/README.md
@@ -3,35 +3,37 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/camacho/format-package.svg)](https://greenkeeper.io/)
 
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL:flags=["-D"]) -->
+
 ```sh
 yarn add -D format-package prettier@^1.6.0
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
-<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true) -->
+<!-- AUTO-GENERATED-CONTENT:START (TOC2:collapse=true) -->
 <details>
 <summary>Table of Contents</summary>
 
 - [Getting started](#getting-started)
-  * [Requirements](#requirements)
-  * [Command Line](#command-line)
-  * [Module](#module)
+  - [Requirements](#requirements)
+  - [Command Line](#command-line)
+  - [Module](#module)
 - [Options](#options)
-  * [Defaults](#defaults)
-  * [`order`](#order)
-  * [`transformations`](#transformations)
-  * [`formatter`](#formatter)
-  * [CLI](#cli)
+  - [Defaults](#defaults)
+  - [`order`](#order)
+  - [`transformations`](#transformations)
+  - [`formatter`](#formatter)
+  - [CLI](#cli)
 - [Configuration Files](#configuration-files)
-  * [Configuration Schema](#configuration-schema)
-  * [Configuration Examples](#configuration-examples)
-  * [with package.json](#with-packagejson)
-  * [with format-package.json](#with-format-packagejson)
-  * [with `format-package.js` or `format-package.config.js`](#with-format-packagejs-or-format-packageconfigjs)
-  * [with format-package.{yml,yaml}, format-package.config.{yml,yaml}](#with-format-packageymlyaml-format-packageconfigymlyaml)
+  - [Configuration Schema](#configuration-schema)
+  - [Configuration Examples](#configuration-examples)
+  - [with package.json](#with-packagejson)
+  - [with format-package.json](#with-format-packagejson)
+  - [with `format-package.js` or `format-package.config.js`](#with-format-packagejs-or-format-packageconfigjs)
+  - [with format-package.{yml,yaml}, format-package.config.{yml,yaml}](#with-format-packageymlyaml-format-packageconfigymlyaml)
 - [Integrating](#integrating)
 - [Development](#development)
-  * [Scripts](#scripts)
+  - [Scripts](#scripts)
 
 </details>
 <!-- AUTO-GENERATED-CONTENT:END -->
@@ -49,8 +51,9 @@ It is configurable to allow teams to pick the order that work best for them, and
 ### Requirements
 
 <!-- AUTO-GENERATED-CONTENT:START (ENGINES) -->
-* **node**: >=7.6.0
-<!-- AUTO-GENERATED-CONTENT:END -->
+
+- **node**: >=7.6.0
+  <!-- AUTO-GENERATED-CONTENT:END -->
 
 ### Command Line
 
@@ -90,6 +93,7 @@ The module exports an _asynchronous_ `format` function that takes the contents o
 It returns a newly sorted and formatted `package.json` string.
 
 <!-- AUTO-GENERATED-CONTENT:START (PRETTIER) -->
+
 ```js
 #!/usr/bin/env node
 
@@ -110,6 +114,7 @@ formatPackage(pkg).catch(err => {
   process.exit(1);
 });
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Options
@@ -123,6 +128,7 @@ There are three options:
 Options are expected to be passed in as a keyed object:
 
 <!-- AUTO-GENERATED-CONTENT:START (PRETTIER) -->
+
 ```js
 const format = require('format-package');
 const pkg = require('<path-to-package.json>');
@@ -133,6 +139,7 @@ const options = {
 };
 format(pkg, options).then(formattedPkg => console.log(formattedPkg));
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ### Defaults
@@ -140,6 +147,7 @@ format(pkg, options).then(formattedPkg => console.log(formattedPkg));
 The `format-package` module also exports its defaults to help with configuration:
 
 <!-- AUTO-GENERATED-CONTENT:START (PRETTIER) -->
+
 ```js
 const format = require('format-package');
 const pkg = require('<path-to-package.json>');
@@ -155,6 +163,7 @@ order.push('...rest');
 
 format(pkg, { order }).then(formattedPkg => console.log(formattedPkg));
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ### `order`
@@ -165,6 +174,7 @@ The default order is:
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./lib/defaults/order.json) -->
 <!-- The below code snippet is automatically added from ./lib/defaults/order.json -->
+
 ```json
 [
   "name",
@@ -200,6 +210,7 @@ The default order is:
   "bundledDependencies"
 ]
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END *-->
 
 The `...rest` value is considered special. It marks the location where the remaining `package.json` keys that are not found in this ordered list will be placed in alphabetical order.
@@ -207,6 +218,7 @@ The `...rest` value is considered special. It marks the location where the remai
 **Note:** if a `...rest` string is not found in the provided order list, it will be appended to the bottom.
 
 <!-- AUTO-GENERATED-CONTENT:START (PRETTIER) -->
+
 ```js
 const format = require('format-package');
 const pkg = require('<path-to-package.json>');
@@ -246,6 +258,7 @@ format(pkg, options).then(formattedPkg =>
 'repository' ]
 */
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END *-->
 
 ### `transformations`
@@ -256,6 +269,7 @@ The default transformations map has a `scripts` method that sorts the scripts in
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./lib/defaults/transformations.js) -->
 <!-- The below code snippet is automatically added from ./lib/defaults/transformations.js -->
+
 ```js
 const sortScripts = require('sort-scripts');
 
@@ -272,6 +286,7 @@ const transformations = {
 
 module.exports = transformations;
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END *-->
 
 **Notes:** Any `package.json` property that is an object **and** does not have a defined transformation will be alphabetically sorted.
@@ -279,6 +294,7 @@ module.exports = transformations;
 Additional transformations or overrides can be passed in:
 
 <!-- AUTO-GENERATED-CONTENT:START (PRETTIER) -->
+
 ```js
 const format = require('format-package');
 const pkg = require('<path-to-package.json>');
@@ -302,6 +318,7 @@ const options = {
 
 format(pkg, options);
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END *-->
 
 ### `formatter`
@@ -314,6 +331,7 @@ By default, the formatter will try to use [`prettier`](https://github.com/pretti
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./lib/defaults/formatter.js) -->
 <!-- The below code snippet is automatically added from ./lib/defaults/formatter.js -->
+
 ```js
 async function formatter(obj) {
   const content = JSON.stringify(obj, null, 2);
@@ -335,6 +353,7 @@ async function formatter(obj) {
 
 module.exports = formatter;
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END *-->
 
 ### CLI
@@ -378,7 +397,10 @@ yarn format-package --help
          a. check if the value resolves to a module id, else
          b. check if value resolves to an existing path
 
-    If either `a` or `b` are valid configuration, then use the configuration, else continue searching.
+    If either `a` or `b` are valid configuration, then use the configuration, else
+    return the [default](lib/defaults/index.js) configuration.
+
+If neither a `--config` or a `FORMAT_PACKAGE_CONFIG` environment variable is provided, search for configurations in the following places:
 
 2.  [`format-package.js`](#with-format-packagejs-or-format-packageconfigjs)
 3.  [`format-package.yaml` or `format-package.yml`](#with-format-packageymlyaml-format-packageconfigymlyaml)
@@ -387,12 +409,17 @@ yarn format-package --help
 6.  [`format-package.config.yaml` or `format-package.config.yml`](#with-format-packageymlyaml-format-packageconfigymlyaml)
 7.  [`format-package`](#with-packagejson) property in `package.json`
 
-If there are no valid configuration, it will use the [default](lib/defaults/index.js).
+If there are no configuration from the above search places, `format-package` will move up one directory level and try again.
+
+`format-package` will continue searching until arriving at the home directory.
+
+If no configuration is found, then the [default](lib/defaults/index.js) configuration is used.
 
 ### Configuration Schema
 
 <!-- AUTO-GENERATED-CONTENT:START (REGION:src=./lib/cli/config-schema.js&region='Joi Schema') -->
 <!-- The below code snippet is automatically added from ./lib/cli/config-schema.js -->
+
 ```js
 const JoiConfigSchema = Joi.object({
   order: Joi.array()
@@ -402,6 +429,7 @@ const JoiConfigSchema = Joi.object({
   formatter: Joi.func().optional(),
 });
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ### Configuration Examples
@@ -412,48 +440,53 @@ Supported configuration formats: JSON, JSON5, JS, and YAML.
 
 <!-- AUTO-GENERATED-CONTENT:START (JSONPROP:src=./examples/format-package-property/package.json&prop=format-package) -->
 <!-- The below code snippet is automatically added from ./examples/format-package-property/package.json -->
+
 ```json
 {
-  "order": [
-    "name",
-    "version"
-  ]
+  "order": ["name", "version"]
 }
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ### with format-package.json
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./examples/format-package-json/format-package.json) -->
 <!-- The below code snippet is automatically added from ./examples/format-package-json/format-package.json -->
+
 ```json
 {
   "order": ["name", "description", "..."]
 }
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ### with `format-package.js` or `format-package.config.js`
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./examples/format-package-config-js/format-package.config.js) -->
 <!-- The below code snippet is automatically added from ./examples/format-package-config-js/format-package.config.js -->
+
 ```js
 module.exports = {
   order: ['name', 'description', '...'],
 };
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ### with format-package.{yml,yaml}, format-package.config.{yml,yaml}
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./examples/format-package-config-yml/format-package.config.yml) -->
 <!-- The below code snippet is automatically added from ./examples/format-package-config-yml/format-package.config.yml -->
+
 ```yml
 order:
   - name
   - description
   - ...
 ```
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Integrating
@@ -506,17 +539,20 @@ yarn install
 These scripts can be run via `yarn` or `npm run`:
 
 <!-- AUTO-GENERATED-CONTENT:START (SCRIPTS) -->
-| Script | Description |
-|--------|-------------|
-| `docs` | updates any auto-generated-content blocks in [Markdown](https://guides.github.com/features/mastering-markdown/) files |
-| `format` | format the application code |
-| `format:package` | `./lib/cli/index.js -w package.json` |
-| `format:source` | `prettier --write "**/*.{md,js,json}"` |
-| `gamut` | run the full gamut of checks - reset environment, generate docs, format and lint code, and run tests |
-| `lint` | lint the application code |
-| `prepublishOnly` | make sure the package is in good state before publishing |
-| `reset` | reset the `node_modules` dependencies |
-| `test` | run unit tests for the application |
+
+| Script           | Description                                                                                                           |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `docs`           | updates any auto-generated-content blocks in [Markdown](https://guides.github.com/features/mastering-markdown/) files |
+| `format`         | format the application code                                                                                           |
+| `format:docs`    | format application documents                                                                                          |
+| `format:package` | format package.json files                                                                                             |
+| `format:source`  | format source content using [prettier](https://github.com/prettier/prettier)                                          |
+| `gamut`          | run the full gamut of checks - reset environment, generate docs, format and lint code, and run tests                  |
+| `lint`           | lint the application code                                                                                             |
+| `prepublishOnly` | make sure the package is in good state before publishing                                                              |
+| `reset`          | reset the `node_modules` dependencies                                                                                 |
+| `test`           | run unit tests for the application                                                                                    |
+
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 **Note** - This repo depends on [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged) to automatically format code and update documents. If these commands are not run, code changes will most likely fail.

--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -4,8 +4,15 @@ Tests in this directory are for more functional checks.
 
 ## `Fixtures`
 
-In addition to any additional functional tests that could be added here, there is also a special directory called [`fixtures`](fixtures) where a `JSON` file can be dropped and automatically run through the `format-package` CLI to verify the output.
+In addition to any additional functional tests that could be added here, there
+is also a special directory called [`fixtures`](fixtures) where a `JSON` file
+can be dropped and automatically run through the `format-package` CLI to verify
+the output.
 
-To add a new test, just create a new `JSON` file in the `fixtures` directory and run `yarn test --watch`. A snapshot will automatically be created for each fixture file found and any changes in output will cause the tests to fail until their snapshots are updated (`yarn test -u`).
+To add a new test, just create a new `JSON` file in the `fixtures` directory and
+run `yarn test --watch`. A snapshot will automatically be created for each
+fixture file found and any changes in output will cause the tests to fail until
+their snapshots are updated (`yarn test -u`).
 
-In addition, custom `.spec.js` files can be added here and will be run as part of the test suite.
+In addition, custom `.spec.js` files can be added here and will be run as part
+of the test suite.

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   "scripts": {
     "docs": "scripts/markdown.js",
     "format": "npm-run-all format:*",
+    "format:docs": "prettier --write '**/*.md'",
     "format:package": "./lib/cli/index.js -w package.json",
-    "format:source": "prettier --write \"**/*.{md,js,json}\"",
+    "format:source": "prettier --write '**/*.{js,json}'",
     "gamut": "npm-run-all reset docs format lint test",
     "lint": "eslint \"**/*.js\"",
     "prepublishOnly": "yarn gamut",

--- a/scripts/markdown.js
+++ b/scripts/markdown.js
@@ -36,6 +36,7 @@ function stageChanges(err, output) {
 
   if (!files.length) return;
 
+  execa.sync('yarn', ['format:docs']);
   execa.sync('git', ['add', ...files]);
 }
 


### PR DESCRIPTION
Fixing conflict with `prettier` and `markdown-magic` when generating TOC.