### PR TITLE
feat: allow prettier 3 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "yargs": "^17.3.1"
   },
   "peerDependencies": {
-    "prettier": "^2.0.0"
+    "prettier": "2 || 3"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.16.7",


### PR DESCRIPTION
Fixes #134.

We've been using this package with Prettier 3 for at least a year and everything works fine.