### PR TITLE
Adopt markdown-magic v4 plugin majors, drop overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL:flags=["-D"]) -->
 
 ```sh
-npm install -D format-package prettier@^2.0.0 || ^3.0.0
+npm add -D format-package "prettier@^2.0.0 || ^3.0.0"
 ```
 
 <!-- AUTO-GENERATED-CONTENT:END -->
@@ -176,7 +176,6 @@ The most meaningful part of this utility is an ordered array of keys that are us
 The default order is:
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./src/lib/defaults/order.json) -->
-<!-- The below code snippet is automatically added from ./src/lib/defaults/order.json -->
 
 ```json
 [
@@ -280,7 +279,6 @@ The default transformations map has:
 - `*` function that sorts the value alphabetically if possible
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./src/lib/defaults/transformations.ts) -->
-<!-- The below code snippet is automatically added from ./src/lib/defaults/transformations.ts -->
 
 ```ts
 import sortScripts from 'sort-scripts';
@@ -354,7 +352,6 @@ A custom _synchronous_ or _asynchronous_ formatter can be supplied that will pro
 By default, the formatter will try to use [`prettier`](https://github.com/prettier/prettier) if it is installed, and will fallback to `JSON.stringify` if the [peer dependency](https://nodejs.org/es/blog/npm/peer-dependencies/) is not found:
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./src/lib/defaults/formatter.ts) -->
-<!-- The below code snippet is automatically added from ./src/lib/defaults/formatter.ts -->
 
 ```ts
 import path from 'path';
@@ -373,7 +370,9 @@ const formatter: Formatter = async (obj, filePath) => {
     return `${content}\n`;
   }
 
-  // prettier@2 is CJS; under ESM the callable API lands on .default
+  // prettier@2 is CJS; under ESM the callable API lands on .default. The
+  // fallback covers a pure-ESM prettier with no default export.
+  /* v8 ignore next -- defensive interop fallback */
   const prettier = prettierMod.default ?? prettierMod;
 
   let config = await prettier.resolveConfig(
@@ -490,7 +489,6 @@ Supported configuration formats: JSON, JSON5, JS, and YAML.
 ### with format-package.json
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./examples/format-package-json/format-package.json) -->
-<!-- The below code snippet is automatically added from ./examples/format-package-json/format-package.json -->
 
 ```json
 {
@@ -503,7 +501,6 @@ Supported configuration formats: JSON, JSON5, JS, and YAML.
 ### with `format-package.js` or `format-package.config.js`
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./examples/format-package-config-js/format-package.config.js) -->
-<!-- The below code snippet is automatically added from ./examples/format-package-config-js/format-package.config.js -->
 
 ```js
 module.exports = {
@@ -516,7 +513,6 @@ module.exports = {
 ### with format-package.{yml,yaml}, format-package.config.{yml,yaml}
 
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./examples/format-package-config-yml/format-package.config.yml) -->
-<!-- The below code snippet is automatically added from ./examples/format-package-config-yml/format-package.config.yml -->
 
 ```yml
 order:

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,16 +28,15 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-import-x": "^4.16.2",
-        "execa": "^5.1.1",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
         "install-deps-postmerge": "^2.0.1",
         "lint-staged": "^17.0.8",
-        "markdown-magic": "^1.0.0",
-        "markdown-magic-engines": "^1.0.2",
-        "markdown-magic-install-command": "^1.3.1",
-        "markdown-magic-package-scripts": "^1.2.1",
-        "markdown-magic-prettier": "^1.0.4",
+        "markdown-magic": "^4.11.0",
+        "markdown-magic-engines": "^2.0.0",
+        "markdown-magic-install-command": "^3.0.0",
+        "markdown-magic-package-scripts": "^2.0.0",
+        "markdown-magic-prettier": "^3.0.0",
         "prettier": "^3.8.4",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.1",
@@ -129,6 +128,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/@davidwells/dx-args": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@davidwells/dx-args/-/dx-args-0.2.2.tgz",
+      "integrity": "sha512-IrYO/reKy4EIa/gl0YSaF7lgGpQ3M2TJsDKgfKMj3qOCRoUIJVzMmvHNcft4lngTb3oS+Z2tKn1jQjDVbagOxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-glob": "^4.0.3",
+        "is-valid-path": "^0.1.1",
+        "mri": "^1.2.0",
+        "oparser": "^3.1.1"
+      },
+      "bin": {
+        "dx-args": "src/index.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@davidwells/md-utils": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@davidwells/md-utils/-/md-utils-0.0.53.tgz",
+      "integrity": "sha512-qAF7lvZ8ZduJQ/9SPfhlYU03/bPdG3g9IQVmfGzPvi0XM5EJPj/8cUMf5bcoIREF1P2nz82LYeFGHTXQ0slJbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "micro-mdx-parser": "^1.1.1",
+        "oparser": "^3.0.1"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -141,14 +171,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@emnapi/core/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
@@ -160,14 +182,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@emnapi/runtime/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -178,14 +192,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -765,14 +771,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@tybys/wasm-util/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1622,17 +1620,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-red": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-wrap": "0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -1657,34 +1644,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/ansi-wrap": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "node_modules/array-uniq": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1708,33 +1676,6 @@
         "js-tokens": "^10.0.0"
       }
     },
-    "node_modules/autolinker": {
-      "version": "0.28.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gulp-header": "^1.7.1"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1743,11 +1684,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/caseless": {
-      "version": "0.11.0",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1840,25 +1776,61 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/coffee-script": {
-      "version": "1.12.7",
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
+      "dependencies": {
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=7.0.0"
       }
     },
-    "node_modules/colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/comment-block-parser": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/comment-block-parser/-/comment-block-parser-1.6.4.tgz",
+      "integrity": "sha512-6eOoZjlhx536BXik5daCjwGTS15uZsJ47FfHT2nftBLXRu2mCrOeY7rGFuzB20/QgRSttlQBgUBJ/jbOGF9Rqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dedent": "^1.6.0",
+        "mri": "^1.2.0",
+        "oparser": "^3.1.1"
+      },
+      "bin": {
+        "comment-block-parser": "cli.js"
+      },
       "engines": {
-        "node": ">=0.1.90"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/comment-block-replacer": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/comment-block-replacer/-/comment-block-replacer-0.1.24.tgz",
+      "integrity": "sha512-Zwnewk8TLf2OKBn8F4QuWh38+WCzqxd+20rWMGJvyF6jiqzon/mnx3jOJqoV64uUsx9wE6fca4PV5U+AUdhQ0g==",
+      "dev": true,
+      "dependencies": {
+        "comment-block-transformer": "0.8.5",
+        "is-valid-path": "^0.1.1"
+      }
+    },
+    "node_modules/comment-block-transformer": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/comment-block-transformer/-/comment-block-transformer-0.8.5.tgz",
+      "integrity": "sha512-AhUKknBQ+d5dbloJlW48oE1C/6i+tKfRyKCPJk+vJOkdNcn1K9ZlhTXBMPqPOp2R285NxMDoHsm187C43FawHQ==",
+      "dev": true,
+      "dependencies": {
+        "comment-block-parser": "1.6.4"
       }
     },
     "node_modules/comment-parser": {
@@ -1871,42 +1843,10 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-with-sourcemaps": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
       "dev": true,
       "license": "MIT"
     },
@@ -1997,6 +1937,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "dev": true,
@@ -2013,20 +1967,27 @@
         }
       }
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deepmerge": {
-      "version": "1.5.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2036,14 +1997,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diacritics-map": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -2097,6 +2050,62 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2300,19 +2309,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/eslint-plugin-import-x/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2436,17 +2432,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/eslint/node_modules/glob-parent/node_modules/is-glob": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2521,6 +2506,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -2554,6 +2555,8 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -2620,71 +2623,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/execa": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/expand-range": {
-      "version": "1.8.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-range/node_modules/fill-range": {
-      "version": "2.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-range/node_modules/isobject": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2696,8 +2651,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2760,39 +2727,20 @@
       }
     },
     "node_modules/find-up": {
-      "version": "2.1.0",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-8.0.0.tgz",
+      "integrity": "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^8.0.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/findup": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-      "integrity": "sha512-Udxo3C9A6alt2GZ2MNsgnIvX7De0V3VGxeP/x98NSVgSlizcDHdmJza61LI7zJy4OEtSiJyE72s0/+tBl5/ZxA==",
-      "dev": true,
-      "dependencies": {
-        "colors": "~0.6.0-1",
-        "commander": "~2.1.0"
+        "node": ">=20"
       },
-      "bin": {
-        "findup": "bin/findup.js"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/findup/node_modules/commander": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-      "integrity": "sha512-J2wnb6TKniXNOtoHS8TSrG9IOQluPrsmyAJ8oCUJOBmv+uLBCyPYAZkD2jFvw2DCzIXNnISIM01NIvr35TkBMQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.x"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat-cache": {
@@ -2813,19 +2761,6 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/for-in": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
       "dev": true,
       "license": "ISC"
     },
@@ -2863,17 +2798,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -2900,34 +2824,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.4",
+    "node_modules/globalyzer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
+      "integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gray-matter": {
-      "version": "2.1.1",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-red": "^0.1.1",
-        "coffee-script": "^1.12.4",
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.8.1",
-        "toml": "^2.3.2"
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gulp-header": {
-      "version": "1.8.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "concat-with-sourcemaps": "*",
-        "lodash.template": "^4.4.0",
-        "through2": "^2.0.0"
+        "node": ">=6.0"
       }
     },
     "node_modules/has-flag": {
@@ -2944,29 +2868,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/http-basic": {
-      "version": "2.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.6",
-        "http-response-object": "^1.0.0"
-      }
-    },
-    "node_modules/http-response-object": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/human-signals": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -3024,20 +2925,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/install-deps-postmerge": {
       "version": "2.0.1",
@@ -3111,11 +2998,6 @@
       "version": "0.2.1",
       "license": "MIT"
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -3128,6 +3010,8 @@
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3159,11 +3043,49 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-glob": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-invalid-path/node_modules/is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-invalid-path/node_modules/is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^1.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -3174,27 +3096,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-number": {
-      "version": "2.1.0",
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.0",
@@ -3204,23 +3111,23 @@
         "node": ">=8"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
+    "node_modules/is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "is-invalid-path": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -3327,7 +3234,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3337,6 +3246,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-alexander": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/json-alexander/-/json-alexander-0.1.14.tgz",
+      "integrity": "sha512-gM2u2bGDQWCAplwKEOo39ETOxZspMYKSzkQPzZ2+bX2gIqOo0im9JjesAs9yKjIE2xDuwOqa5pLEJ/M/O4Mv3g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -3384,31 +3300,11 @@
       }
     },
     "node_modules/kind-of": {
-      "version": "3.2.2",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/klaw": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
-    "node_modules/lazy-cache": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "set-getter": "^0.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3719,20 +3615,6 @@
         "yaml": "^2.9.0"
       }
     },
-    "node_modules/list-item": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expand-range": "^1.8.1",
-        "extend-shallow": "^2.0.1",
-        "is-number": "^2.1.0",
-        "repeat-string": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/listr2": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
@@ -3751,38 +3633,27 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "2.0.0",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-8.0.0.tgz",
+      "integrity": "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^6.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -3857,6 +3728,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3895,190 +3776,190 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/markdown-link": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/markdown-magic": {
-      "version": "1.0.0",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/markdown-magic/-/markdown-magic-4.11.0.tgz",
+      "integrity": "sha512-GTdLzcvFZ/07V0cA7G6/7c9cPLX7M4WBJD8aIhIdfPHnv6l36I5fSc+Fx6O9wtnJG0P9+jSeA3W8C14zAyWpDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^2.9.0",
-        "deepmerge": "^1.3.0",
-        "find-up": "^2.1.0",
-        "fs-extra": "^1.0.0",
-        "globby": "^6.1.0",
+        "@davidwells/dx-args": "0.2.2",
+        "@davidwells/md-utils": "0.0.53",
+        "color-convert": "^2.0.1",
+        "comment-block-parser": "1.6.4",
+        "comment-block-replacer": "0.1.24",
+        "comment-block-transformer": "0.8.5",
+        "globrex": "^0.1.2",
+        "gray-matter": "^4.0.3",
+        "is-glob": "^4.0.3",
         "is-local-path": "^0.1.6",
-        "markdown-toc": "^1.2.0",
-        "sync-request": "^3.0.1"
+        "is-valid-path": "^0.1.1",
+        "micro-mdx-parser": "^1.1.0",
+        "module-alias": "^2.2.3",
+        "mri": "^1.2.0",
+        "node-fetch": "^2.7.0",
+        "punycode": "^2.3.1",
+        "smart-glob": "^1.0.2",
+        "string-width": "^4.2.3"
       },
       "bin": {
         "markdown": "cli.js",
-        "md-magic": "cli.js"
+        "md-magic": "cli.js",
+        "mdm": "cli.js"
       }
     },
     "node_modules/markdown-magic-engines": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-magic-engines/-/markdown-magic-engines-1.0.3.tgz",
-      "integrity": "sha512-GP0VdViysgbB8kLY0IPDK0CEj97NG8jseMcr87Ue5uH8iHrxdbIzPeAqHvTTzBEP76pribXp2REYetOtNs5H9A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-magic-engines/-/markdown-magic-engines-2.0.0.tgz",
+      "integrity": "sha512-2ov2bwGT1hkwFF74l0lVkQI5jC+PSlCYJx3Z76u0sIvErL9a8EnxdoYUDzPY81wvRr0yJ19tCoSrBAy2Bb+dAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "findup": "^0.1.5"
+        "find-up": "^8.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "markdown-magic": ">=0.1 <=2.x"
+        "markdown-magic": "^4"
       }
     },
     "node_modules/markdown-magic-install-command": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/markdown-magic-install-command/-/markdown-magic-install-command-1.3.1.tgz",
-      "integrity": "sha512-xI+YGUPs4LxVlcO8xm9zzGcZSl6WBfJXptSiqQ0EPLljum2C7RCZjZlGc5X+FoB/MHgqDzi2u3Bo9UIB8ppCmQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-magic-install-command/-/markdown-magic-install-command-3.0.0.tgz",
+      "integrity": "sha512-Z7nV3VOFr+GVu4H7FSO7OY16RS1HcXUxt4O5V80QN/xl+p/5T6ZNiNC0Wp0Ayii3pu+QRjbcr+pL3CPwi43K9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "findup": "^0.1.5"
+        "find-up": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "peerDependencies": {
+        "markdown-magic": "^4"
       }
     },
     "node_modules/markdown-magic-package-scripts": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/markdown-magic-package-scripts/-/markdown-magic-package-scripts-1.2.2.tgz",
-      "integrity": "sha512-dlCojsiJLV9BcL8ar03qycI0H5quM47Ei+mh14It0dTYhLAoH8B/91J0/pLDX3Wba9wTkPCbEKzNVvV8ea0WlQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-magic-package-scripts/-/markdown-magic-package-scripts-2.0.0.tgz",
+      "integrity": "sha512-I4SXftfRnJgijJBJW1fG6hJ/A6rPARksLtqpc8sJjbV9cVyIf6wmDydSXef6spd1DiyRvCZgXLv9mMPUWIvOSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "findup": "^0.1.5",
+        "find-up": "^8.0.0",
         "sort-scripts": "^1.0.1"
       },
+      "engines": {
+        "node": ">=22.18.0"
+      },
       "peerDependencies": {
-        "markdown-magic": ">=0.1 <=2.x"
+        "markdown-magic": "^4"
       }
     },
     "node_modules/markdown-magic-prettier": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-magic-prettier/-/markdown-magic-prettier-1.0.4.tgz",
-      "integrity": "sha512-sb40DCEEUFxhPONjkizpLCIPZsNPfrv4JJ9PI+pNL9vT3D6YZ34q6npTTIKED44QPP6thn+97bfyuE6LWGVQLw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-magic-prettier/-/markdown-magic-prettier-3.0.0.tgz",
+      "integrity": "sha512-XDidN4O9uUEaAt6F29ID7Yo/CCZROiMhVf8h0uPvqfRPhHCTgW4heuZRn74aDNfNCMWIfsM5+L7BImddJvmUpA==",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "prettier": "^1.5.3"
-      }
-    },
-    "node_modules/markdown-magic/node_modules/array-union": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=22.18.0"
+      },
+      "peerDependencies": {
+        "markdown-magic": "^4",
+        "prettier": "^3"
       }
     },
-    "node_modules/markdown-magic/node_modules/commander": {
-      "version": "2.20.0",
+    "node_modules/markdown-magic/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/markdown-magic/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/markdown-magic/node_modules/fs-extra": {
-      "version": "1.0.0",
+    "node_modules/markdown-magic/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/markdown-magic/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "node_modules/markdown-magic/node_modules/glob": {
-      "version": "7.1.4",
+    "node_modules/markdown-magic/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
       },
       "engines": {
-        "node": "*"
+        "node": ">=0.12"
       }
-    },
-    "node_modules/markdown-magic/node_modules/globby": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/markdown-magic/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/markdown-magic/node_modules/pify": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/markdown-toc": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "^1.5.2",
-        "diacritics-map": "^0.1.0",
-        "gray-matter": "^2.1.0",
-        "lazy-cache": "^2.0.2",
-        "list-item": "^1.1.1",
-        "markdown-link": "^0.1.1",
-        "minimist": "^1.2.0",
-        "mixin-deep": "^1.1.3",
-        "object.pick": "^1.2.0",
-        "remarkable": "^1.7.1",
-        "repeat-string": "^1.6.1",
-        "strip-color": "^0.1.0"
-      },
-      "bin": {
-        "markdown-toc": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/math-random": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/micro-mdx-parser": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/micro-mdx-parser/-/micro-mdx-parser-1.1.27.tgz",
+      "integrity": "sha512-lv55o5jPRjcnGCBMOF+DQAqa+74UNhXulTROefjjPKLh2GPWTyQHbF0gRiwS9mc5ftQbElzX0r8T0TNmIeIONQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oparser": "^3.0.22"
+      }
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -4101,43 +3982,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.6",
+    "node_modules/module-alias": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.3.4.tgz",
+      "integrity": "sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mixin-deep": {
-      "version": "1.3.2",
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mixin-deep/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -4185,12 +4044,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -4201,25 +4088,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.pick": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/obug": {
@@ -4260,6 +4128,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oparser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oparser/-/oparser-3.1.1.tgz",
+      "integrity": "sha512-gESndQMHLfymx2xXgFdxqcyYJ7qKDF5ZHcbbt8DGLSBGIg01dEusRDlcGEkvgwvRdM4u2hGXrnUOFgancT3bLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-alexander": "^0.1.14"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4279,33 +4157,48 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "1.3.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-try": "^1.0.0"
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "2.0.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parent-module": {
@@ -4318,22 +4211,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -4368,25 +4245,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -4533,17 +4391,14 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/promise": {
-      "version": "7.3.1",
+    "node_modules/promisify-child-process": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-4.1.2.tgz",
+      "integrity": "sha512-APnkIgmaHNJpkAn7k+CrJSi9WMuff5ctYFbD0CO2XIPkM8yO7d/ShouU2clywbpHV/DUsyc4bpJCsNgddNtx4g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "asap": "~2.0.3"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pump": {
@@ -4567,86 +4422,14 @@
         "node": ">=6"
       }
     },
-    "node_modules/qs": {
-      "version": "6.7.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/randomatic": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/randomatic/node_modules/is-number": {
-      "version": "4.0.0",
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/randomatic/node_modules/kind-of": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/remarkable": {
-      "version": "1.7.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.10",
-        "autolinker": "~0.28.0"
-      },
-      "bin": {
-        "remarkable": "bin/remarkable.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/repeat-element": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/resolve-from": {
@@ -4753,10 +4536,19 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.4",
@@ -4769,17 +4561,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/set-getter": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-object-path": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/shebang-command": {
@@ -4815,6 +4596,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
@@ -4832,17 +4623,159 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smart-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/smart-glob/-/smart-glob-1.0.2.tgz",
+      "integrity": "sha512-2vtznbLOW+7sL9xUhJNszHw7lEeigPbkp6l42gCbY6uMzC9MSyroIMBLO1PtsEoq7PG1NGF99VNt9sCC2D/bTw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "globalyzer": "^0.1.4",
+        "globrex": "^0.1.2",
+        "lodash": "^4.17.20",
+        "memoizee": "^0.4.14",
+        "promisify-child-process": "^4.1.1",
+        "slash": "^3.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^16.0.3"
+      },
+      "bin": {
+        "smart-glob": "dist/bin.js"
+      }
+    },
+    "node_modules/smart-glob/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-glob/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/smart-glob/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/smart-glob/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/smart-glob/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-glob/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-glob/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-glob/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smart-glob/node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-glob/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sort-scripts": {
       "version": "1.0.1",
       "license": "MIT"
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -4856,6 +4789,8 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -4882,14 +4817,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -4933,8 +4860,10 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strip-color": {
-      "version": "0.1.0",
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4949,36 +4878,18 @@
         "node": ">=6"
       }
     },
-    "node_modules/sync-request": {
-      "version": "3.0.1",
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "concat-stream": "^1.4.7",
-        "http-response-object": "^1.0.1",
-        "then-request": "^2.0.1"
-      }
-    },
-    "node_modules/then-request": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.7",
-        "http-basic": "^2.5.1",
-        "http-response-object": "^1.1.0",
-        "promise": "^7.1.1",
-        "qs": "^6.1.0"
-      }
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/tinybench": {
@@ -5025,19 +4936,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/to-object-path": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/toml": {
-      "version": "2.3.6",
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5054,6 +4956,20 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5066,11 +4982,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -5116,6 +5027,19 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
@@ -5164,11 +5088,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vitest": {
       "version": "4.1.9",
@@ -5365,6 +5284,24 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -5428,14 +5365,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -69,21 +69,6 @@
       "npm run dev -- -w package.json"
     ]
   },
-  "overrides": {
-    "markdown-magic-engines": {
-      "markdown-magic": "$markdown-magic"
-    },
-    "markdown-magic-install-command": {
-      "markdown-magic": "$markdown-magic"
-    },
-    "markdown-magic-package-scripts": {
-      "markdown-magic": "$markdown-magic"
-    },
-    "markdown-magic-prettier": {
-      "markdown-magic": "$markdown-magic",
-      "prettier": "$prettier"
-    }
-  },
   "dependencies": {
     "cosmiconfig": "^9.0.2",
     "joi": "^18.2.3",
@@ -104,16 +89,15 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import-x": "^4.16.2",
-    "execa": "^5.1.1",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "install-deps-postmerge": "^2.0.1",
     "lint-staged": "^17.0.8",
-    "markdown-magic": "^1.0.0",
-    "markdown-magic-engines": "^1.0.2",
-    "markdown-magic-install-command": "^1.3.1",
-    "markdown-magic-package-scripts": "^1.2.1",
-    "markdown-magic-prettier": "^1.0.4",
+    "markdown-magic": "^4.11.0",
+    "markdown-magic-engines": "^2.0.0",
+    "markdown-magic-install-command": "^3.0.0",
+    "markdown-magic-package-scripts": "^2.0.0",
+    "markdown-magic-prettier": "^3.0.0",
     "prettier": "^3.8.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",

--- a/scripts/markdown-transformers.ts
+++ b/scripts/markdown-transformers.ts
@@ -3,16 +3,30 @@ import { readFileSync } from 'node:fs';
 
 import JSON5 from 'json5';
 
+interface TransformOptions {
+  src?: string;
+  syntax?: string;
+  region?: string;
+  header?: string;
+  prop?: string;
+}
+
+interface TransformArgs {
+  content: unknown;
+  options: TransformOptions;
+  srcPath: string;
+}
+
 // stolen from markdown-magic/lib/transforms/code.js
-export function REGION(_: unknown, options, config) {
-  let code;
+export function REGION({ options, srcPath }: TransformArgs): string | false {
+  let code: string;
   let { syntax } = options;
 
   if (!options.src) {
     return false;
   }
 
-  const fileDir = path.dirname(config.originalPath);
+  const fileDir = path.dirname(srcPath);
   const filePath = path.join(fileDir, options.src);
 
   try {
@@ -26,7 +40,7 @@ export function REGION(_: unknown, options, config) {
     syntax = path.extname(filePath).replace(/^./, '');
   }
 
-  const region = options.region.replace(/['"]/g, '');
+  const region = (options.region ?? '').replace(/['"]/g, '');
 
   const pattern = new RegExp(
     `([^]*?)?/{2} region ${region}[\n]([^]*?)\n/{2} endregion`,
@@ -34,8 +48,8 @@ export function REGION(_: unknown, options, config) {
   );
 
   if (pattern.test(code)) {
-    code = code.match(pattern);
-    code = code[0].replace(pattern, '$2');
+    const match = code.match(pattern);
+    code = match ? match[0].replace(pattern, '$2') : code;
   } else {
     throw new Error(`Region not found: ${region}.`);
   }
@@ -54,19 +68,19 @@ ${code}
 \`\`\``;
 }
 
-export function JSONPROP(content, options, config) {
-  let code;
+export function JSONPROP({ options, srcPath }: TransformArgs): string | false {
   let { syntax } = options;
 
   if (!options.src) {
     return false;
   }
 
-  const fileDir = path.dirname(config.originalPath);
+  const fileDir = path.dirname(srcPath);
   const filePath = path.join(fileDir, options.src);
 
+  let raw: string;
   try {
-    code = readFileSync(filePath, 'utf8');
+    raw = readFileSync(filePath, 'utf8');
   } catch (e) {
     console.log(`FILE NOT FOUND ${filePath}`);
     throw e;
@@ -76,9 +90,9 @@ export function JSONPROP(content, options, config) {
     syntax = path.extname(filePath).replace(/^./, '');
   }
 
-  code = JSON5.parse(code);
-  code = code[`${options.prop}`] || code;
-  code = JSON.stringify(code, null, 2);
+  const parsed = JSON5.parse(raw) as Record<string, unknown>;
+  const code = (options.prop && parsed[options.prop]) || parsed;
+  const stringified = JSON.stringify(code, null, 2);
 
   let header = '';
   if (options.header) {
@@ -87,6 +101,6 @@ export function JSONPROP(content, options, config) {
 
   return `<!-- The below code snippet is automatically added from ${options.src} -->
 \`\`\`${syntax}${header}
-${code}
+${stringified}
 \`\`\``;
 }

--- a/scripts/markdown.ts
+++ b/scripts/markdown.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
 
-import execa from 'execa';
-import markdownMagic from 'markdown-magic';
+import { markdownMagic } from 'markdown-magic';
 import SCRIPTS from 'markdown-magic-package-scripts';
 import PRETTIER from 'markdown-magic-prettier';
 import ENGINES from 'markdown-magic-engines';
@@ -16,6 +16,7 @@ const globs = [`${root}/**/**.md`, `!${root}/node_modules/**`];
 
 // Add any configurations here
 const config = {
+  matchWord: 'AUTO-GENERATED-CONTENT',
   transforms: {
     SCRIPTS,
     PRETTIER,
@@ -28,24 +29,13 @@ const config = {
 
 const target = process.argv[2] || globs;
 
-function stageChanges(
-  error: Error,
-  output: {
-    outputFilePath: string;
-  }[]
-): void {
-  if (error) {
-    throw error;
-  }
-
-  const files = output
-    .map((data) => data.outputFilePath)
-    .filter((file) => !!file);
-
+function stageChanges(files: string[]): void {
   if (!files.length) return;
 
-  execa.sync('npx', ['prettier', '--write', ...files]);
-  execa.sync('git', ['add', ...files]);
+  execFileSync('npx', ['prettier', '--write', ...files]);
+  execFileSync('git', ['add', ...files]);
 }
 
-markdownMagic(target, config, stageChanges);
+const { filesChanged } = await markdownMagic(target, config);
+
+stageChanges(filesChanged);


### PR DESCRIPTION
Closes #156. Feeds #153.

## Changes
- markdown-magic ^1 → ^4.11; markdown-magic-{engines 2, install-command 3, package-scripts 2, prettier 3} — the modernized majors now published from [markdown-magic-plugins](https://github.com/camacho/markdown-magic-plugins)
- **`overrides` block deleted** — it existed to force the old plugins' `>=0.1 <=2.x` markdown-magic peer onto v1; the new plugins declare `^4` peers
- `scripts/markdown.ts`: v1 callback API → v4 (`import { markdownMagic }`, awaited, explicit `matchWord`); post-run prettier+git-add now via `node:child_process` — `execa` devDep removed (nothing else used it)
- `scripts/markdown-transformers.ts`: REGION/JSONPROP on the v4 object signature (`{ content, options, srcPath }`) with a local typed interface (upstream types transforms as `any`); logic byte-for-byte unchanged
- README regenerated: the long-broken INSTALL line renders correctly quoted again; five CODE blocks drop a comment line upstream v4 no longer emits; one stale-comment catch-up

## Validation
- `npm run gamut` end-to-end (docs regeneration idempotent across consecutive runs, hash-verified)
- Review included fault injection: a broken REGION reference correctly rejects and exits 1
- Known/unchanged: TOC2 block still has no registered transform (tracked in #153); the `error.test.ts` inline snapshots assume a no-color environment (pass in CI and under `FORCE_COLOR=0` locally) — pre-existing on main

## Notes
- Doc generation is fully functional again under v4 + prettier 3 (async transforms) — this resolves the core blocker documented in #153; TOC2 registration is the remaining #153 item